### PR TITLE
AnswerHandler

### DIFF
--- a/RiddleBot/src/main/java/io/kemper/AnswerHandler.java
+++ b/RiddleBot/src/main/java/io/kemper/AnswerHandler.java
@@ -32,7 +32,7 @@ public class AnswerHandler implements RequestStreamHandler {
 
 
         //TODO there must be a more elegant way of doing this
-        
+
         Map<String, Object> map = mapper.readValue(qsp.toString(), new TypeReference<Map<String,Object>>(){});
         Object idObject = map.get("id");
         int id = 0;

--- a/RiddleBot/src/main/java/io/kemper/AnswerHandler.java
+++ b/RiddleBot/src/main/java/io/kemper/AnswerHandler.java
@@ -1,0 +1,50 @@
+package io.kemper;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kemper.api.Response;
+import io.kemper.db.DBHandler;
+import io.kemper.db.SimpleDBHandler;
+
+import java.io.*;
+
+
+public class AnswerHandler implements RequestStreamHandler {
+    DBHandler dbHandler;
+
+    public AnswerHandler() {
+        this.dbHandler = new SimpleDBHandler();
+    }
+
+    @Override
+    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+        LambdaLogger logger = context.getLogger();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        OutputStreamWriter writer = new OutputStreamWriter(output, "UTF-8");
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode actualObj = mapper.readTree(reader);
+        String idString = actualObj.get("queryStringParameters").get("id").toString();
+        logger.log("---------ID STRING: " + idString + "--------------");
+        try {
+            int id = Integer.parseInt(idString);
+            String answer = dbHandler.getRiddleByID(id).getAnswer();
+            Response response = new Response(answer, 200);
+            writer.write(marshall(response));
+        } catch (Exception e) {
+            String answer = "idString is " + idString;
+            Response response = new Response(answer, 200);
+            writer.write(marshall(response));
+        } finally {
+            writer.close();
+        }
+    }
+
+    public String marshall(Response r) throws JsonProcessingException {
+        ObjectMapper om = new ObjectMapper();
+        return om.writeValueAsString(r);
+    }
+}

--- a/RiddleBot/src/main/java/io/kemper/db/DBHandler.java
+++ b/RiddleBot/src/main/java/io/kemper/db/DBHandler.java
@@ -1,0 +1,12 @@
+package io.kemper.db;
+
+import io.kemper.domain.Riddle;
+
+/** Interface for getting Riddle data
+ *
+ */
+public interface DBHandler {
+    Riddle getRandomRiddle();
+
+    Riddle getRiddleByID(int id);
+}

--- a/RiddleBot/src/main/java/io/kemper/db/SimpleDBHandler.java
+++ b/RiddleBot/src/main/java/io/kemper/db/SimpleDBHandler.java
@@ -1,0 +1,38 @@
+package io.kemper.db;
+
+import io.kemper.domain.Riddle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/** Mock implementation of DBHandler. Uses in-memory data.
+ *
+ */
+public class SimpleDBHandler implements DBHandler {
+
+    List<Riddle> riddles;
+    Random randy;
+
+    public SimpleDBHandler() {
+        randy = new Random();
+        riddles = new ArrayList<>();
+
+        riddles.add(new Riddle("Riddle 1 Q", "Riddle 1 A" ));
+        riddles.add(new Riddle("Riddle 2 Q", "Riddle 2 A" ));
+        riddles.add(new Riddle("Riddle 3 Q", "Riddle 3 A" ));
+        riddles.add(new Riddle("Riddle 4 Q", "Riddle 4 A" ));
+        riddles.add(new Riddle("Riddle 5 Q", "Riddle 5 A" ));
+        riddles.add(new Riddle("Riddle 6 Q", "Riddle 6 A" ));
+    }
+    @Override
+    public Riddle getRandomRiddle() {
+        int id = randy.nextInt(riddles.size());
+        return getRiddleByID(id);
+    }
+
+    @Override
+    public Riddle getRiddleByID(int id) {
+        return riddles.get(id);
+    }
+}

--- a/RiddleBot/src/test/java/io/kemper/AnswerHandlerTest.java
+++ b/RiddleBot/src/test/java/io/kemper/AnswerHandlerTest.java
@@ -1,0 +1,40 @@
+package io.kemper;
+
+import io.kemper.api.Response;
+import io.kemper.db.DBHandler;
+import io.kemper.db.SimpleDBHandler;
+import org.junit.Test;
+import com.amazonaws.services.lambda.runtime.Context;
+
+
+import java.io.*;
+
+import static org.junit.Assert.assertTrue;
+
+public class AnswerHandlerTest {
+
+    DBHandler dbHandler = new SimpleDBHandler();
+
+    static String inString = "{" +
+            "    \"resource\": \"Resource path\"," +
+            "    \"path\": \"Path parameter\"," +
+            "    \"httpMethod\": \"Incoming request's method name\"," +
+            "    \"headers\": \"aktest\"," +
+            "    \"queryStringParameters\": {\"id\": 1}," +
+            "    \"pathParameters\":  \"aktest\"," +
+            "    \"stageVariables\": \"aktest\"," +
+            "    \"requestContext\": \"aktest\"," +
+            "    \"body\": \"A JSON string of the request payload.\"," +
+            "    \"isBase64Encoded\": \"A boolean flag to indicate if the applicable request payload is Base64-encode\"" +
+            "}";
+
+    @Test
+    public void testAnswerHandler() throws IOException {
+        InputStream is = new ByteArrayInputStream( inString.getBytes() );
+        OutputStream os = new ByteArrayOutputStream();
+        Context context = new TestContext();
+        AnswerHandler ah = new AnswerHandler();
+        ah.handleRequest(is, os, context);
+        assertTrue(os.toString().contains(dbHandler.getRiddleByID(1).getAnswer()));
+    }
+}


### PR DESCRIPTION
Create AnswerHandler lambda that gets riddle answers by id (using RequestStreamHandler this tiem). Also, create DBHandler interface and a simple implementation that can be exchanged for real database solution in the future.

I think we can get rid of #2, as the handler you wrote used lambda proxy integration, and I followed the same strategy of marshalling with the Response object in Jackson to adhere to the format at http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html#api-gateway-simple-proxy-for-lambda-output-format

